### PR TITLE
Fix dynamodb fetch/register

### DIFF
--- a/matchHandler.js
+++ b/matchHandler.js
@@ -4,7 +4,7 @@ const matchService = require('./service/matchService');
 
 const handleRegisterResult = async event => {
   try {
-    const result = await matchService.registerMatchResult(event);
+    const result = await matchService.registerMatchResult(JSON.parse(event.body));
     return { statusCode: 201, body: JSON.stringify(result) };
   } catch (e) {
     return { statusCode: 500, body: `An unexpected error has occurred ${e}` }

--- a/model/match.js
+++ b/model/match.js
@@ -1,9 +1,5 @@
 class Match {
 
-    constructor() {
-        this.matchTypes = ["SQUAD", "DUO", "ARENA-SINGLE", "ARENA-THREESOME"];
-    }
-
     matchId(matchId) {
         this.matchId = matchId;
         return this;
@@ -34,7 +30,9 @@ class Match {
     }
 
     matchType(matchType) {
-        if (this.matchTypes.includes(matchType)) {
+        const matchTypes = ["SQUAD", "DUO", "ARENA-SINGLE", "ARENA-THREESOME"];
+
+        if (matchTypes.includes(matchType)) {
             this.matchType = matchType;
             return this;
         }

--- a/service/mapper/matchMapper.js
+++ b/service/mapper/matchMapper.js
@@ -13,12 +13,12 @@ class MatchMapper {
 
     toRecord(matchResource) {
         return {
-            "matchId": { S: matchResource.matchId },
-            "startTime": { S: matchResource.startTime },
-            "endTime": { S: matchResource.endTime },
-            "winnerId": { S: matchResource.winnerId },
-            "playersNumber": { N: matchResource.playersNumber.toString() },
-            "matchType": { S: matchResource.matchType }
+            "matchId": matchResource.matchId,
+            "startTime": matchResource.startTime,
+            "endTime": matchResource.endTime,
+            "winnerId": matchResource.winnerId,
+            "playersNumber": matchResource.playersNumber,
+            "matchType": matchResource.matchType
         }
     }
 }

--- a/service/matchService.js
+++ b/service/matchService.js
@@ -10,27 +10,28 @@ class MatchService {
         this.matchMapper = new MatchMapper();
     }
 
-    async registerMatchResult({ body }) {
-        const match = this.matchMapper.toResource(body);
+    async registerMatchResult(matchResult) {
+        const match = this.matchMapper.toResource(matchResult);
 
-        return this.dynamoClient.putItem({ TableName: MatchService.TABLE_NAME, Item: this.matchMapper.toRecord(match)})
+        console.log("matchRecord ->", this.matchMapper.toRecord(match));
+
+        return this.dynamoClient.put({ TableName: MatchService.TABLE_NAME, Item: this.matchMapper.toRecord(match)})
             .promise()
             .then(matchResult)
             .catch(e => { throw new Error(`A tremendous error has occurred ${e.stack}`); });
     }
 
     async fetchResult(matchId) {
-        return this.dynamoClient.get({ TableName: MatchService.TABLE_NAME, Key: { "matchId": { S: matchId } }})
+        return this.dynamoClient.get({ TableName: MatchService.TABLE_NAME, Key: { "matchId": matchId } })
             .promise()
             .then(data => {
-                console.log(`-----> ${data.Item}`);
-                if (!data.Item) {
+                console.log(`-----> ${JSON.stringify(data)}`);
+                if (data.Item === undefined) {
                     throw new Error(`Ah bueno adios master :v`);
                 }
-                return data;
+                return data.Item;
             })
-            .then(item => DynamoDB.Converter.unmarshall(item))
-            .then(parsedItem => this.matchMapper.toResource(parsedItem))
+            .then(item => this.matchMapper.toResource(item))
             .catch(e => { throw new Error(`A tremendous error has occurred ${e.stack}`); });
     }
 }

--- a/service/matchService.js
+++ b/service/matchService.js
@@ -13,26 +13,23 @@ class MatchService {
     async registerMatchResult(matchResult) {
         const match = this.matchMapper.toResource(matchResult);
 
-        console.log("matchRecord ->", this.matchMapper.toRecord(match));
-
         return this.dynamoClient.put({ TableName: MatchService.TABLE_NAME, Item: this.matchMapper.toRecord(match)})
             .promise()
             .then(matchResult)
-            .catch(e => { throw new Error(`A tremendous error has occurred ${e.stack}`); });
+            .catch(e => { throw new Error(`An error has occurred ${e.stack}`); });
     }
 
     async fetchResult(matchId) {
         return this.dynamoClient.get({ TableName: MatchService.TABLE_NAME, Key: { "matchId": matchId } })
             .promise()
             .then(data => {
-                console.log(`-----> ${JSON.stringify(data)}`);
                 if (data.Item === undefined) {
-                    throw new Error(`Ah bueno adios master :v`);
+                    throw new Error(`The requested item does not exist`);
                 }
                 return data.Item;
             })
             .then(item => this.matchMapper.toResource(item))
-            .catch(e => { throw new Error(`A tremendous error has occurred ${e.stack}`); });
+            .catch(e => { throw new Error(`An error has occurred ${e.stack}`); });
     }
 }
 


### PR DESCRIPTION
Using the document client, we can get rid of types and avoid marshalling/unmarshalling stuff. This is a very basic fix and yet there are things to do in another PR:

- Return 404 when the requested record can not be found in dynamo.
- Extract mapping and clients access in a commons library, then reuse it.
- Standarize logging.
- Standarize error structures and centralize error messages.